### PR TITLE
pwkit/lmmin.py: avoid yet another deprecated Numpy API

### DIFF
--- a/pwkit/lmmin.py
+++ b/pwkit/lmmin.py
@@ -1328,7 +1328,7 @@ class Problem(object):
         p[PI_F_STEP] = 0.0
         p[PI_F_MAXSTEP] = np.inf
 
-        newinfoo = p = np.ndarray((PI_NUM_O, npar), dtype=np.object)
+        newinfoo = p = np.ndarray((PI_NUM_O, npar), dtype=object)
         p[PI_O_TIEFUNC] = None
 
         newinfob = p = np.ndarray(npar, dtype=int)


### PR DESCRIPTION
It never ends! (It would end if we had a test suite.)