### PR TITLE
pwkit/kwargv.py: fix fixup processing of args with non-None defaults

### DIFF
--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -67,15 +67,18 @@ steps:
   - bash: |
       set -euo pipefail
 
-      if [[ $AGENT_OS == Windows_NT ]] ; then
+      if [[ $AGENT_OS == Darwin ]] ; then
+        # As of macos-14, these no longer have Anaconda built in.
+        CONDA="$TMPDIR/conda"
+        curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh >miniforge.sh
+        bash miniforge.sh -f -b -p "$CONDA"
+        rm -f miniforge.sh
+        condabin="$CONDA/bin"
+      elif [[ $AGENT_OS == Windows_NT ]] ; then
         CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         condabin="$CONDA/Scripts"
       else
         condabin="$CONDA/bin"
-      fi
-
-      if [[ $AGENT_OS == Darwin ]] ; then
-        sudo chown -R $USER $CONDA
       fi
 
       cat >activate-conda.sh <<EOF

--- a/pwkit/kwargv.py
+++ b/pwkit/kwargv.py
@@ -370,8 +370,14 @@ class ParseKeywords(Holder):
                 ki.default = None
             elif ki.repeatable:
                 ki.default = []
-            elif ki.fixupfunc is not None and ki.default is not None:
-                # kinda gross structure here, oh well.
+            elif ki.fixupfunc is not None:
+                # Make sure to process the default through the fixup, if it
+                # exists. This helps code use "interesting" defaults with types
+                # that you might prefer to use when launching a task
+                # programmatically; e.g. a default output stream that is
+                # `sys.stdout`, not "-". Note, however, that the fixup will
+                # always get called for the default value, so it shouldn't do
+                # anything too expensive.
                 ki.default = ki.fixupfunc(ki.default)
 
             kwinfos[kw] = ki
@@ -471,14 +477,6 @@ class ParseKeywords(Holder):
                     raise KwargvError(
                         'required keyword argument "%s" was not provided', kw
                     )
-
-                # If there's a fixup, process it even if the keyword wasn't
-                # provided. This lets code use "interesting" defaults with
-                # types that you might prefer to use when launching a task
-                # programmatically; e.g. a default output stream that is
-                # `sys.stdout`, not "-".
-                if ki.fixupfunc is not None:
-                    self.set_one(ki._attrname, ki.fixupfunc(None))
 
         return self  # convenience
 


### PR DESCRIPTION
The fixup function was being called twice if an argument had a default that wasn't None, leading to problems in `omegafig`.